### PR TITLE
Small PR: Refactor mergeWithDelegate Method to Adhere to SOLID Principles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "java.compile.nullAnalysis.mode": "automatic",
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/account/src/main/java/org/killbill/billing/account/api/DefaultAccount.java
+++ b/account/src/main/java/org/killbill/billing/account/api/DefaultAccount.java
@@ -300,8 +300,12 @@ public class DefaultAccount extends EntityBase implements Account {
     }
 
     
-
-    public void accountDataSetter(final DefaultMutableAccountData accountData, final Account currentAccount) {
+	/**
+	 * 
+	 * @param accountData
+	 * @param currentAccount
+	 */
+    private void accountDataSetter(final DefaultMutableAccountData accountData, final Account currentAccount) {
     	
     	
     	// Set all updatable fields with the new values if non null, otherwise defaults to the current values
@@ -327,6 +331,22 @@ public class DefaultAccount extends EntityBase implements Account {
 	      accountData.setIsPaymentDelegatedToParent(isPaymentDelegatedToParent != null ? isPaymentDelegatedToParent : currentAccount.isPaymentDelegatedToParent());
     }
     
+    /**
+     * 
+     * @param currentAccount
+     */
+    private void validate(final Account currentAccount) {
+    	validateAccountUpdateInput(currentAccount, false);
+    }
+    /**
+     * 
+     * @param currentAccount
+     * @param accountData
+     * @return 
+     */
+    private DefaultAccount createDefaultAccount(Account currentAccount, DefaultMutableAccountData accountData) {
+    	return new DefaultAccount(currentAccount.getId(), accountData);
+    }
     
     /**
      * @param currentAccount existing account data
@@ -337,7 +357,7 @@ public class DefaultAccount extends EntityBase implements Account {
     public Account mergeWithDelegate(final Account currentAccount) {
         final DefaultMutableAccountData accountData = new DefaultMutableAccountData(this);
 
-        validateAccountUpdateInput(currentAccount, false);
+        validate(currentAccount);
 
         accountData.setExternalKey(currentAccount.getExternalKey());
 
@@ -358,7 +378,7 @@ public class DefaultAccount extends EntityBase implements Account {
             accountData.setIsMigrated(isMigrated);
         }
 
-        return new DefaultAccount(currentAccount.getId(), accountData);
+        return createDefaultAccount(currentAccount, accountData);
     }
 
     @Override

--- a/account/src/main/java/org/killbill/billing/account/api/DefaultAccount.java
+++ b/account/src/main/java/org/killbill/billing/account/api/DefaultAccount.java
@@ -299,6 +299,35 @@ public class DefaultAccount extends EntityBase implements Account {
         return new DefaultMutableAccountData(this);
     }
 
+    
+
+    public void accountDataSetter(final DefaultMutableAccountData accountData, final Account currentAccount) {
+    	
+    	
+    	// Set all updatable fields with the new values if non null, otherwise defaults to the current values
+	      accountData.setEmail(email != null ? email : currentAccount.getEmail());
+	      accountData.setName(name != null ? name : currentAccount.getName());
+	      final Integer firstNameLength = this.firstNameLength != null ? this.firstNameLength : currentAccount.getFirstNameLength();
+	      if (firstNameLength != null) {
+	          accountData.setFirstNameLength(firstNameLength);
+	      }
+	      accountData.setPaymentMethodId(paymentMethodId != null ? paymentMethodId : currentAccount.getPaymentMethodId());
+	      accountData.setTimeZone(timeZone != null ? timeZone : currentAccount.getTimeZone());
+	      accountData.setLocale(locale != null ? locale : currentAccount.getLocale());
+	      accountData.setAddress1(address1 != null ? address1 : currentAccount.getAddress1());
+	      accountData.setAddress2(address2 != null ? address2 : currentAccount.getAddress2());
+	      accountData.setCompanyName(companyName != null ? companyName : currentAccount.getCompanyName());
+	      accountData.setCity(city != null ? city : currentAccount.getCity());
+	      accountData.setStateOrProvince(stateOrProvince != null ? stateOrProvince : currentAccount.getStateOrProvince());
+	      accountData.setCountry(country != null ? country : currentAccount.getCountry());
+	      accountData.setPostalCode(postalCode != null ? postalCode : currentAccount.getPostalCode());
+	      accountData.setPhone(phone != null ? phone : currentAccount.getPhone());
+	      accountData.setNotes(notes != null ? notes : currentAccount.getNotes());
+	      accountData.setParentAccountId(parentAccountId != null ? parentAccountId : currentAccount.getParentAccountId());
+	      accountData.setIsPaymentDelegatedToParent(isPaymentDelegatedToParent != null ? isPaymentDelegatedToParent : currentAccount.isPaymentDelegatedToParent());
+    }
+    
+    
     /**
      * @param currentAccount existing account data
      * @return merged account data
@@ -322,27 +351,8 @@ public class DefaultAccount extends EntityBase implements Account {
             accountData.setBillCycleDayLocal(currentAccount.getBillCycleDayLocal());
         }
 
-        // Set all updatable fields with the new values if non null, otherwise defaults to the current values
-        accountData.setEmail(email != null ? email : currentAccount.getEmail());
-        accountData.setName(name != null ? name : currentAccount.getName());
-        final Integer firstNameLength = this.firstNameLength != null ? this.firstNameLength : currentAccount.getFirstNameLength();
-        if (firstNameLength != null) {
-            accountData.setFirstNameLength(firstNameLength);
-        }
-        accountData.setPaymentMethodId(paymentMethodId != null ? paymentMethodId : currentAccount.getPaymentMethodId());
-        accountData.setTimeZone(timeZone != null ? timeZone : currentAccount.getTimeZone());
-        accountData.setLocale(locale != null ? locale : currentAccount.getLocale());
-        accountData.setAddress1(address1 != null ? address1 : currentAccount.getAddress1());
-        accountData.setAddress2(address2 != null ? address2 : currentAccount.getAddress2());
-        accountData.setCompanyName(companyName != null ? companyName : currentAccount.getCompanyName());
-        accountData.setCity(city != null ? city : currentAccount.getCity());
-        accountData.setStateOrProvince(stateOrProvince != null ? stateOrProvince : currentAccount.getStateOrProvince());
-        accountData.setCountry(country != null ? country : currentAccount.getCountry());
-        accountData.setPostalCode(postalCode != null ? postalCode : currentAccount.getPostalCode());
-        accountData.setPhone(phone != null ? phone : currentAccount.getPhone());
-        accountData.setNotes(notes != null ? notes : currentAccount.getNotes());
-        accountData.setParentAccountId(parentAccountId != null ? parentAccountId : currentAccount.getParentAccountId());
-        accountData.setIsPaymentDelegatedToParent(isPaymentDelegatedToParent != null ? isPaymentDelegatedToParent : currentAccount.isPaymentDelegatedToParent());
+        accountDataSetter(accountData, currentAccount);
+        
         final Boolean isMigrated = this.isMigrated != null ? this.isMigrated : currentAccount.isMigrated();
         if (isMigrated != null) {
             accountData.setIsMigrated(isMigrated);


### PR DESCRIPTION
Overview
This pull request refactors the existing mergeWithDelegate method within the Account class to better adhere to the SOLID principles, specifically addressing violations of the Single Responsibility Principle (SRP) and the Open/Closed Principle (OCP). By extracting the field-setting logic into a separate method, we enhance the maintainability, readability, and scalability of the codebase.

Background
Original Implementation Issues
The original mergeWithDelegate method performed multiple tasks, leading to several SOLID principle violations:

Single Responsibility Principle (SRP):

Violation: The method handled validation, data merging, conditional logic, and object creation all within a single block. This multi-faceted responsibility made the method complex and harder to maintain or extend.
Open/Closed Principle (OCP):

Violation: The method required modifications every time a new field was added to the Account class. This necessity for frequent changes indicated that the method was not closed for modification and was thus not easily extendable.
Refactoring Changes
Extracted accountDataSetter Method
To address the aforementioned issues, the field-setting logic has been extracted into a new method named accountDataSetter. This separation of concerns allows each method to focus on a single responsibility, thereby enhancing compliance with SRP and laying the groundwork for better adherence to OCP.

Updated mergeWithDelegate Method
The mergeWithDelegate method has been simplified to delegate the field-setting responsibility to the newly created accountDataSetter method. This change ensures that mergeWithDelegate focuses solely on high-level operations such as validation, conditional logic for bill cycle day, and object creation.

How This Refactoring Addresses SOLID Principles

Single Responsibility Principle (SRP)
Before Refactoring:
The mergeWithDelegate method was responsible for multiple tasks: validation, data merging, conditional logic, and object creation.
After Refactoring:

mergeWithDelegate: Now primarily handles validation, conditional logic for specific fields (e.g., billCycleDayLocal), and the creation of the DefaultAccount object.
accountDataSetter: Solely responsible for updating the account fields based on new values or retaining existing ones.
Benefit:

Each method now has a clear, singular purpose, making the codebase easier to understand, maintain, and extend.
2. Open/Closed Principle (OCP)
Before Refactoring:

Adding new fields to the Account class required modifications to the mergeWithDelegate method, making it open to changes.
After Refactoring:

Encapsulation of Field Logic: By isolating the field-setting logic into accountDataSetter, any future changes related to field updates are confined to this method.
Ease of Extension: New fields can be added to accountDataSetter without altering the high-level logic in mergeWithDelegate, thereby reducing the risk of introducing bugs in unrelated parts of the method.
Benefit:

The mergeWithDelegate method is now more resistant to changes, adhering better to the OCP by being closed for modification but open for extension through helper methods.
Additional Improvements and Recommendations
While this refactoring significantly improves adherence to SRP and OCP, further enhancements can be considered to fully align with all SOLID principles and improve overall code quality:

Dependency Inversion Principle (DIP):

Current Status: The methods depend on concrete classes like DefaultMutableAccountData and DefaultAccount.
Recommendation: Introduce abstractions (e.g., interfaces) for account data manipulation and account creation. This change would decouple the high-level methods from specific implementations, enhancing flexibility and testability.
Use of Design Patterns:

Builder Pattern: Implementing a builder for DefaultMutableAccountData can streamline the object creation process and further separate concerns.
Factory Pattern: Utilizing factories for creating account objects can encapsulate instantiation logic and adhere to DIP.
Validation Separation:

Consider moving the validateAccountUpdateInput call to a dedicated validator class or method to further isolate responsibilities.
Utilize Mapping Libraries:

Libraries like MapStruct or ModelMapper can automate the mapping and merging of fields, reducing boilerplate code and potential errors.
Enhanced Documentation and Testing:

Ensure that both the mergeWithDelegate and accountDataSetter methods are well-documented.
Develop comprehensive unit tests for the new accountDataSetter method to ensure reliable field updates.

Conclusion:
This refactoring enhances the mergeWithDelegate method by adhering more closely to the Single Responsibility Principle and Open/Closed Principle of the SOLID design principles. By delegating the field-setting logic to a separate method, the codebase becomes more modular, maintainable, and scalable. Future improvements, such as introducing abstractions and design patterns, can further solidify the code's compliance with SOLID principles and overall robustness.